### PR TITLE
Fix link title in footer

### DIFF
--- a/themes/budibase/layouts/partials/footer.html
+++ b/themes/budibase/layouts/partials/footer.html
@@ -29,7 +29,7 @@
           <!-- List Group -->
           <div class="list-group list-group-flush ">
             <a class="list-group-item list-group-item-action" href="/product">Features</a>
-            <a class="list-group-item list-group-item-action" href="/components">Integrations</a>
+            <a class="list-group-item list-group-item-action" href="/components">Components</a>
             <a class="list-group-item list-group-item-action" href="/integration">Integrations</a>
             <a class="list-group-item list-group-item-action" href="/templates">Templates</a>
             <a class="list-group-item list-group-item-action" href="/pricing">Pricing</a>


### PR DESCRIPTION
Link to Components page in footer was wrongly labelled as link to Integration page. This PR fixes it. 