### PR TITLE
Lcp optimization

### DIFF
--- a/themes/budibase/layouts/partials/header.html
+++ b/themes/budibase/layouts/partials/header.html
@@ -31,7 +31,6 @@
   {{ template "_internal/schema.html" . }}
 
   <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700;900&display=swap" rel="stylesheet">
-  <script async defer data-domain="budibase.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
   <meta name="google-site-verification" content="QgOVKYVI1aszwZ0J4F7zXYmte4scDnnIi6JswcZt_bU" />
 
   </head>

--- a/themes/budibase/layouts/templates/single.html
+++ b/themes/budibase/layouts/templates/single.html
@@ -48,7 +48,7 @@
 
       </div>
         <div>
-        {{ with .Params.preview }}<img class="img-fluid mb-6 rounded-sm" fetchpriority="high" src="{{ . }}">{{ end }}
+          <img class="img-fluid mb-6 rounded-sm" alt="{{ .Title }}" fetchpriority="high" src="{{ .Params.preview }}">
       </div>
       </div>
         <div class="template-content">

--- a/themes/budibase/layouts/templates/single.html
+++ b/themes/budibase/layouts/templates/single.html
@@ -8,9 +8,10 @@
       <a href="{{ .Section }}/templates" class="mb-8 a-alt text-xs">{{.Section | humanize }} templates</a>
     </div>
       <article>
-        <header class="template-header mb-4">
+        <div class="hero-container mb-6">
+          <div>
+        <header class="template-header mb-3">
           <h1 class="">{{ .Params.label }}</h1>
-          <a href="{{ .Params.destination }}" class="btn btn-cta btn-lg sm-btn-block">Use this template</a>
         </header>
         <div class="template-meta">
           <div>
@@ -25,14 +26,6 @@
                 d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             <p class="text-sm text-light">Free</p>
-          </div>
-          <div class="template-meta-info mr-4">
-            <svg xmlns="http://www.w3.org/2000/svg" class="u-xs-avatar mr-1" fill="none" viewBox="0 0 24 24"
-              stroke="gray">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
-            </svg>
-            <p class="text-sm text-light">{{ .Params.datasource }}</p>
           </div>
           <div class="template-meta-info mr-3">
             <svg xmlns="http://www.w3.org/2000/svg" class="u-xs-avatar mr-1" fill="none" viewBox="0 0 24 24"
@@ -51,7 +44,13 @@
             <p class="text-sm text-light">Works on all devices</p>
           </div>
         </div>
-        {{ with .Params.preview }}<img class="img-fluid w-100 mb-6 rounded-sm" width="1600" height="900" fetchpriority="high" src="{{ . }}">{{ end }}
+        <a href="{{ .Params.destination }}" class="btn btn-cta btn-lg sm-btn-block">Use this template</a>
+
+      </div>
+        <div>
+        {{ with .Params.preview }}<img class="img-fluid mb-6 rounded-sm" fetchpriority="high" src="{{ . }}">{{ end }}
+      </div>
+      </div>
         <div class="template-content">
           <aside class="template-toc rounded-sm position-sticky-lg sticky-subnav mt-4 top">
             <h4 class="mb-2">Table of contents</h4>

--- a/themes/budibase/layouts/templates/single.html
+++ b/themes/budibase/layouts/templates/single.html
@@ -51,7 +51,7 @@
             <p class="text-sm text-light">Works on all devices</p>
           </div>
         </div>
-        {{ with .Params.preview }}<img class="img-fluid w-100 mb-6 rounded-sm" src="{{ . }}">{{ end }}
+        {{ with .Params.preview }}<img class="img-fluid w-100 mb-6 rounded-sm" width="1600" height="900" fetchpriority="high" src="{{ . }}">{{ end }}
         <div class="template-content">
           <aside class="template-toc rounded-sm position-sticky-lg sticky-subnav mt-4 top">
             <h4 class="mb-2">Table of contents</h4>

--- a/themes/budibase/static/css/main.css
+++ b/themes/budibase/static/css/main.css
@@ -3190,7 +3190,7 @@ border-radius: .75rem;
 #TableOfContents > ul > li > a {
   display: flex; 
   cursor: pointer;
-  padding: 8px 0; 
+  padding: 20px 0 12px 0; 
   align-items: center;
   text-decoration: none;
   color: var(--gray900);


### PR DESCRIPTION
I've fixed the layout shift - pretty straight forward. Updated the design, provided default widths:
<img width="1900" alt="CleanShot 2022-06-09 at 11 11 47@2x" src="https://user-images.githubusercontent.com/49767913/172823424-3277b753-09c4-4ea7-b601-fba1b3c7d61c.png">


I can optimize LCP using the following code, but the actual user experience is slow. I prefer to deliver a faster web page/asset over a few points on Lighthouse.

```
{{ with .Params.preview }}
<video class="img-fluid mb-6 rounded-sm" autoplay loop fetchpriority="high" src="{{ trim . ".gif" }}.webm">
{{ end }}
```
The above code transforms 90% of the images. Some images are stored locally and cannot be transformed. Others have the word GIF within the URL which would need changed.


