### PR TITLE
Integrate pricing page with account portal api structure and linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ $RECYCLE.BIN/
 
 # OSX
 .DS_Store
+*.iml

--- a/themes/budibase/layouts/partials/pricing-faqs.html
+++ b/themes/budibase/layouts/partials/pricing-faqs.html
@@ -8,7 +8,7 @@
         <h2 class="mb-3">Day passes</h2>
         <p class="text-xs">Most software pricing is designed to charge you per user regardless of how many people on your
             team are actively using the software. At Budibase, you only get billed for what you use, so you don’t pay
-            for the users who aren’t using Budibase. Fair’s fair. <b>With day passes, if a user uses Budibase on a single calendar day, one day pass is used. For example, if a user uses Budibase (including apps built) on Monday, Tuesday and Wednesday, but not Thursday and Friday - that's 3 day passes deducted from your monthly quota. </b></p>
+            for the users who aren’t using Budibase. Fair’s fair. <b>With day passes, if a user uses Budibase within a 24 hour period, one day pass is used. For example, if a user uses Budibase (including apps built) on Monday, Wednesday and Friday, but not Tuesday and Thursday - that's 3 day passes deducted from your monthly quota. </b></p>
     </div>
 </div>
 
@@ -31,7 +31,7 @@
             <summary>What are day passes?</summary>
             <p class="mb-2 text-sm mx-3">Most software pricing is designed to charge you per user regardless of how many people on your
                 team are actively using the software. At Budibase, you only get billed for what you use, so you don’t pay
-                for the users who aren’t using Budibase. Fair’s fair. With day passes, if a user uses Budibase on a single calendar day, one day pass is used. For example, if a user uses Budibase (including apps built) on Monday, Tuesday and Wednesday, but not Thursday and Friday - that's 3 day passes deducted from your quota.</p>
+                for the users who aren’t using Budibase. Fair’s fair. With day passes, if a user uses Budibase within a 24 hour period, one day pass is used. For example, if a user uses Budibase (including apps built) on Monday, Wednesday and Friday, but not Tuesday and Thursday - that's 3 day passes deducted from your quota. If a user uses Budibase on Monday afternoon and Tuesday morning - a single day pass is deducted from your quota.</p>
         </details>
         <details class="border-bottom py-3">
             <summary>Do you charge for users?</summary>
@@ -49,9 +49,9 @@
         </details>
         <details class="border-bottom py-3">
             <summary>What happens when I hit my usage limits?</summary>
-            <p class="mb-2 text-sm mx-3">If you reach your plan's limits, you’ll still be able to use your apps. We’ll
-                let you know about the overage, and give you a grace period to find a plan that fits your
-                needs!</p>
+            <p class="mb-2 text-sm mx-3">If you're close to reaching your plan's limits, we'll you know in advance.
+                Once you reach your plan's limits, for example day passes, your apps will be taken offline until the next quota reset.
+            </p>
         </details>
         <details class="border-bottom py-3">
             <summary>What are my payment options?</summary>

--- a/themes/budibase/layouts/pricing/single.html
+++ b/themes/budibase/layouts/pricing/single.html
@@ -2,7 +2,7 @@
 <div class="container mx-auto">
   <div class="pricing-card-title space-2-top">
     <h1 class="mb-3 text-center">Simple, fair, scalable pricing</h1>
-    <p class="w-lg-45 mb-6 mx-auto text-center">Try for free. When you upgrade, only pay for day passes. If a user uses Budibase on Monday and Tuesday - that's 2 day passes. Never pay for users who aren’t using Budibase apps.
+    <p class="w-lg-45 mb-6 mx-auto text-center">Try for free. When you upgrade, only pay for day passes. If a user uses Budibase on Monday and Wednesday - that's 2 day passes. Never pay for users who aren’t using Budibase apps.
     </div>
 
   <div class="pricing-tabs-container flex-row gap-md mb-4">
@@ -15,6 +15,7 @@
   </div>
 
   <div class="pricing space-1-bottom">
+    <!--Free tier-->
     <div class="pricing-card border-grey bg-light2 rounded">
       <div class="pricing-card-top">
         <h2 class="mb-2 h3 text-dark plan-type">Free</h2>
@@ -23,13 +24,12 @@
         <h3 class="h2 mb-1 mr-2 ">$0</h3>
         <p class="text-xxs">Free forever</p>
         <p class="text-xxs mb-5">No credit card required</p>
-        <select name="team-packages" id="team-packages" class="mb-4 pricing-select">
+        <select name="free-packages" id="free-select" class="mb-4 pricing-select">
           <option  value="50">40 day passes /mo</option>
         </select>        
-        <a href="https://account.budibase.app/register?utm_source=website&utm_medium=cta&utm_campaign=open-source-pricing"
-          target="_blank"><button type="submit" class="btn btn-block btn-primary btn-lg mb-4">
+        <button onClick="goToAccountPortal('free');"  type="submit" class="btn btn-block btn-primary btn-lg mb-4">
             Create free account
-          </button></a>
+        </button>
       </div>
       <div class="pricing-card-bottom">
         <div class="pricing-features">
@@ -75,9 +75,6 @@
       </div>
     </div>
 
-
-
-
     <!--Pro tier-->
     <div class="pricing-card bg-light2 border-grey rounded-sm ">
       <div class="pricing-card-top">
@@ -86,20 +83,15 @@
           <div class="tag-blue ml-auto font-weight-semi-bold">Popular</div> </div>
         <p class="mb-3 text-xxs">More power and functionality for users and small teams.
         </p>
-        <h3 class="h2 mb-1 mr-2 plan-price">$30</h3>
+        <h3 class="h2 mb-1 mr-2 plan-price"></h3>
         <p class="text-xxs">per month, billed annually or</p>
-        <p class="text-xxs mb-5">$36 billed monthly</p>
-        <select name="team-packages" id="team-packages" class="mb-4 pricing-select ">
-          <option  value="50">50 day passes /mo</option>
-          <option value="75">75 day passes /mo</option>
-          <option value="100">100 day passes /mo</option>
+        <p class="text-xxs mb-5 plan-price-monthly" ></p>
+        <select name="pro-packages" id="pro-select" class="mb-4 pricing-select ">
         </select>  
-        <a href="https://account.budibase.app/register?utm_source=website&utm_medium=cta&utm_campaign=open-source-pricing"
-          target="_blank"><button type="submit" class="btn btn-block btn-cta btn-lg mb-4">
+        <button onClick="goToAccountPortal();" type="submit" class="btn btn-block btn-cta btn-lg mb-4">
             Try for free
-          </button></a>
+          </button>
       </div>
-
 
       <div class="pricing-card-bottom">
         <div class="pricing-features">
@@ -130,27 +122,20 @@
       </div>
     </div>
 
-
     <!--Team tier-->
     <div class="pricing-card bg-light2 border-grey rounded-sm ">
       <div class="pricing-card-top">
           <h2 class="mb-2 h3 text-dark plan-type">Team</h2>
         <p class="mb-3 text-xxs">For teams and small businesses who want to move faster.</p>
-        <h3 class="h2 mb-1 plan-price">$70</h3>
+        <h3 class="h2 mb-1 plan-price"></h3>
         <p class="text-xxs">per month, billed annually or</p>
-        <p class="text-xxs mb-5">$10 billed monthly</p>
-        <select name="team-packages" id="team-packages" class="mb-4 pricing-select ">
-          <option  value="100">100 day passes /mo</option>
-          <option value="200">200 day passes /mo</option>
-          <option value="300">300 day passes /mo</option>
-          <option value="400">400 day passes /mo</option>
-          <option value="500">500 day passes /mo</option>
-        </select>  
-        <button type="submit" class="btn btn-block btn-primary btn-lg mb-4">
+        <p class="text-xxs mb-5 plan-price-monthly"></p>
+        <select name="team-packages" id="team-select" class="mb-4 pricing-select ">
+        </select>
+        <button onClick="goToAccountPortal();" type="submit" class="btn btn-block btn-primary btn-lg mb-4">
           Try for free
         </button>
       </div>
-
 
       <div class="pricing-card-bottom">
         <div class="pricing-features">
@@ -195,18 +180,12 @@
       <div class="pricing-card-top">
           <h2 class="mb-2 h3 text-dark plan-type">Business</h2>
           <p class="mb-3 text-xxs">For businesses who need to securely scale development.</p>
-        <h3 class="h2 mb-1 plan-price">$400</h3>
+        <h3 class="h2 mb-1 plan-price"></h3>
         <p class="text-xxs">per month, billed annually or</p>
-        <p class="text-xxs mb-5">$10 billed monthly</p>
-        <select name="team-packages" id="team-packages" class="mb-4 pricing-select ">
-          <option value="500">500 day passes /mo</option>
-          <option value="1000">1K day passes /mo</option>
-          <option value="1500">1.5K day passes /mo</option>
-          <option value="2000">2K day passes /mo</option>
-          <option value="3000">3K day passes /mo</option>
-          <option value="5000">5K day passes /mo</option>
+        <p class="text-xxs mb-5 plan-price-monthly"></p>
+        <select name="business-packages" id="business-select" class="mb-4 pricing-select">
         </select>  
-        <button type="submit" class="btn btn-block btn-primary btn-lg mb-4">
+        <button onClick="goToAccountPortal();" type="submit" class="btn btn-block btn-primary btn-lg mb-4">
           Try for free
         </button>
       </div>
@@ -257,8 +236,8 @@
         <h3 class="h2 mb-1">Custom</h3>
         <p class="text-xxs">Starting at $20k per annum.</p>
         <p class="text-xxs mb-5">Multi-year contracts available.</p>
-        <select name="team-packages" id="team-packages" class="mb-4 pricing-select ">
-          <option  value="50" class="dropdown-item">Custom</option>
+        <select name="enterprise-packages" id="enterprise-select" class="mb-4 pricing-select ">
+          <option value="50" class="dropdown-item">Custom</option>
         </select>  
         <a href="https://budibase.com/contact/" target="_blank"><button type="submit"
             class="btn btn-block btn-primary btn-lg mb-4">
@@ -312,36 +291,9 @@
   </div>
 </div>
 
-
-
-
 {{ partial "pricing-faqs.html" . }}
 {{ partial "cta.html" . }}
 {{ partial "footer.html" . }}
 
-<script>
-  const price = document.querySelector(".plan-price")
-  const packagePickers = document.querySelectorAll(".pricing-select")
-
-  function getPrice(dayPasses, planType) {
-    // change these to update prices 
-    const MULTIPLIERS = {
-      Free: 0.7,
-      Pro: 0.6,
-      Team: 0.7,
-      Business: 0.8
-    }
-
-    return MULTIPLIERS[planType] * dayPasses
-  }
-
-  // set up event listeners for the pickers
-  for (let picker of packagePickers) {
-    picker.addEventListener("change", e => {
-      const parent = e.target.parentElement
-      const planType = parent.querySelector(".plan-type").textContent
-      parent.querySelector(".plan-price").innerHTML = `$${getPrice(e.target.value, planType)}`
-    })
-  }
-  
-</script>
+<!-- JS -->
+<script src="{{ "js/pricing.js" | absURL }}"></script>

--- a/themes/budibase/layouts/pricing/single.html
+++ b/themes/budibase/layouts/pricing/single.html
@@ -2,7 +2,7 @@
 <div class="container mx-auto">
   <div class="pricing-card-title space-2-top">
     <h1 class="mb-3 text-center">Simple, fair, scalable pricing</h1>
-    <p class="w-lg-45 mb-6 mx-auto text-center">Try for free. When you upgrade, only pay for day passes. If a user uses Budibase on Monday and Wednesday - that's 2 day passes. Never pay for users who aren’t using Budibase apps.
+    <p class="w-lg-45 mb-6 mx-auto text-center">When you upgrade, only pay for day passes. If a user uses Budibase on Monday and Wednesday - that's 2 day passes. Never pay for users who aren’t using Budibase apps.
     </div>
 
   <div class="pricing-tabs-container flex-row gap-md mb-4">
@@ -89,7 +89,7 @@
         <select name="pro-packages" id="pro-select" class="mb-4 pricing-select ">
         </select>  
         <button onClick="goToAccountPortal();" type="submit" class="btn btn-block btn-cta btn-lg mb-4">
-            Try for free
+            Upgrade now
           </button>
       </div>
 
@@ -133,7 +133,7 @@
         <select name="team-packages" id="team-select" class="mb-4 pricing-select ">
         </select>
         <button onClick="goToAccountPortal();" type="submit" class="btn btn-block btn-primary btn-lg mb-4">
-          Try for free
+          Upgrade now
         </button>
       </div>
 
@@ -186,7 +186,7 @@
         <select name="business-packages" id="business-select" class="mb-4 pricing-select">
         </select>  
         <button onClick="goToAccountPortal();" type="submit" class="btn btn-block btn-primary btn-lg mb-4">
-          Try for free
+          Upgrade now
         </button>
       </div>
       <div class="pricing-card-bottom">

--- a/themes/budibase/layouts/self-host/single.html
+++ b/themes/budibase/layouts/self-host/single.html
@@ -2,7 +2,7 @@
 <div class="container mx-auto">
   <div class="pricing-card-title space-2-top text-center ">
     <h1 class="mb-3 text-center">Simple, fair, scalable pricing</h1>
-    <p class="w-lg-45 mb-6 mx-auto text-center">Try for free. When you upgrade, only pay for day passes. If a user uses Budibase on Monday and Wednesday - that's 2 day passes. Never pay for users who aren’t using Budibase apps.
+    <p class="w-lg-45 mb-6 mx-auto text-center">When you upgrade, only pay for day passes. If a user uses Budibase on Monday and Wednesday - that's 2 day passes. Never pay for users who aren’t using Budibase apps.
     </div>
 
   <div class="pricing-tabs-container flex-row gap-md mb-4">
@@ -82,7 +82,7 @@
         <select name="pro-packages" id="pro-select" class="mb-4 pricing-select ">
         </select>  
         <button onClick="goToAccountPortal();" type="submit" class="btn btn-block btn-cta btn-lg mb-4">
-            Try for free
+            Upgrade now
         </button>
       </div>
 
@@ -115,7 +115,7 @@
         <select name="team-packages" id="team-select" class="mb-4 pricing-select ">
         </select>  
         <button onClick="goToAccountPortal();" type="submit" class="btn btn-block btn-primary btn-lg mb-4">
-          Try for free
+          Upgrade now
         </button>
       </div>
 
@@ -161,7 +161,7 @@
         <select name="business-packages" id="business-select" class="mb-4 pricing-select">
         </select>  
         <button onClick="goToAccountPortal();" type="submit" class="btn btn-block btn-primary btn-lg mb-4">
-          Try for free
+          Upgrade now
         </button>
       </div>
       <div class="pricing-card-bottom">

--- a/themes/budibase/layouts/self-host/single.html
+++ b/themes/budibase/layouts/self-host/single.html
@@ -2,7 +2,7 @@
 <div class="container mx-auto">
   <div class="pricing-card-title space-2-top text-center ">
     <h1 class="mb-3 text-center">Simple, fair, scalable pricing</h1>
-    <p class="w-lg-45 mb-6 mx-auto text-center">Try for free. When you upgrade, only pay for day passes. If a user uses Budibase on Monday and Tuesday - that's 2 day passes. Never pay for users who aren’t using Budibase apps.
+    <p class="w-lg-45 mb-6 mx-auto text-center">Try for free. When you upgrade, only pay for day passes. If a user uses Budibase on Monday and Wednesday - that's 2 day passes. Never pay for users who aren’t using Budibase apps.
     </div>
 
   <div class="pricing-tabs-container flex-row gap-md mb-4">
@@ -14,9 +14,8 @@
     </div>
   </div>
 
-
-  
   <div class="pricing space-1-bottom">
+    <!-- Free tier -->
     <div class="pricing-card border-grey bg-light2 rounded">
       <div class="pricing-card-top">
         <h2 class="mb-2 h3 text-dark plan-type">Open source</h2>
@@ -25,13 +24,12 @@
         <h3 class="h2 mb-1 mr-2 ">$0</h3>
         <p class="text-xxs">Free forever</p>
         <p class="text-xxs mb-5">No credit card required</p>
-        <select name="team-packages" id="team-packages" class="mb-4 pricing-select">
+        <select name="free-packages" id="free-select" class="mb-4 pricing-select">
           <option  value="50">N/A</option>
-        </select>        
-        <a href="https://account.budibase.app/register?utm_source=website&utm_medium=cta&utm_campaign=open-source-pricing"
-          target="_blank"><button type="submit" class="btn btn-block btn-primary btn-lg mb-4">
+        </select>
+        <button onClick="goToAccountPortal('free');" type="submit" class="btn btn-block btn-primary btn-lg mb-4">
             Create free account
-          </button></a>
+        </button>
       </div>
       <div class="pricing-card-bottom">
         <div class="pricing-features">
@@ -70,9 +68,6 @@
       </div>
     </div>
 
-
-
-
     <!--Pro tier-->
     <div class="pricing-card bg-light2 border-grey rounded-sm ">
       <div class="pricing-card-top">
@@ -81,20 +76,15 @@
           <div class="tag-blue ml-auto font-weight-semi-bold">Popular</div> </div>
         <p class="mb-3 text-xxs">More power and functionality for users and small teams.
         </p>
-        <h3 class="h2 mb-1 mr-2 plan-price">$30</h3>
+        <h3 class="h2 mb-1 mr-2 plan-price"></h3>
         <p class="text-xxs">per month, billed annually or</p>
-        <p class="text-xxs mb-5">$36 billed monthly</p>
-        <select name="team-packages" id="team-packages" class="mb-4 pricing-select ">
-          <option  value="50">50 day passes /mo</option>
-          <option value="75">75 day passes /mo</option>
-          <option value="100">100 day passes /mo</option>
+        <p class="text-xxs mb-5 plan-price-monthly"></p>
+        <select name="pro-packages" id="pro-select" class="mb-4 pricing-select ">
         </select>  
-        <a href="https://account.budibase.app/register?utm_source=website&utm_medium=cta&utm_campaign=open-source-pricing"
-          target="_blank"><button type="submit" class="btn btn-block btn-cta btn-lg mb-4">
+        <button onClick="goToAccountPortal();" type="submit" class="btn btn-block btn-cta btn-lg mb-4">
             Try for free
-          </button></a>
+        </button>
       </div>
-
 
       <div class="pricing-card-bottom">
         <div class="pricing-features">
@@ -114,27 +104,20 @@
       </div>
     </div>
 
-
     <!--Team tier-->
     <div class="pricing-card bg-light2 border-grey rounded-sm ">
       <div class="pricing-card-top">
           <h2 class="mb-2 h3 text-dark plan-type">Team</h2>
         <p class="mb-3 text-xxs">For teams and small businesses who want to move faster.</p>
-        <h3 class="h2 mb-1 plan-price">$70</h3>
+        <h3 class="h2 mb-1 plan-price"></h3>
         <p class="text-xxs">per month, billed annually or</p>
-        <p class="text-xxs mb-5">$10 billed monthly</p>
-        <select name="team-packages" id="team-packages" class="mb-4 pricing-select ">
-          <option  value="100">100 day passes /mo</option>
-          <option value="200">200 day passes /mo</option>
-          <option value="300">300 day passes /mo</option>
-          <option value="400">400 day passes /mo</option>
-          <option value="500">500 day passes /mo</option>
+        <p class="text-xxs mb-5 plan-price-monthly"></p>
+        <select name="team-packages" id="team-select" class="mb-4 pricing-select ">
         </select>  
-        <button type="submit" class="btn btn-block btn-primary btn-lg mb-4">
+        <button onClick="goToAccountPortal();" type="submit" class="btn btn-block btn-primary btn-lg mb-4">
           Try for free
         </button>
       </div>
-
 
       <div class="pricing-card-bottom">
         <div class="pricing-features">
@@ -172,18 +155,12 @@
       <div class="pricing-card-top">
           <h2 class="mb-2 h3 text-dark plan-type">Business</h2>
           <p class="mb-3 text-xxs">For businesses who need to securely scale development.</p>
-        <h3 class="h2 mb-1 plan-price">$400</h3>
+        <h3 class="h2 mb-1 plan-price"></h3>
         <p class="text-xxs">per month, billed annually or</p>
-        <p class="text-xxs mb-5">$10 billed monthly</p>
-        <select name="team-packages" id="team-packages" class="mb-4 pricing-select ">
-          <option value="500">500 day passes /mo</option>
-          <option value="1000">1K day passes /mo</option>
-          <option value="1500">1.5K day passes /mo</option>
-          <option value="2000">2K day passes /mo</option>
-          <option value="3000">3K day passes /mo</option>
-          <option value="5000">5K day passes /mo</option>
+        <p class="text-xxs mb-5 plan-price-monthly"></p>
+        <select name="business-packages" id="business-select" class="mb-4 pricing-select">
         </select>  
-        <button type="submit" class="btn btn-block btn-primary btn-lg mb-4">
+        <button onClick="goToAccountPortal();" type="submit" class="btn btn-block btn-primary btn-lg mb-4">
           Try for free
         </button>
       </div>
@@ -227,7 +204,7 @@
         <h3 class="h2 mb-1">Custom</h3>
         <p class="text-xxs">Starting at $20k per annum.</p>
         <p class="text-xxs mb-5">Multi-year contracts available.</p>
-        <select name="team-packages" id="team-packages" class="mb-4 pricing-select ">
+        <select name="enterprise-packages" id="enterprise-select" class="mb-4 pricing-select ">
           <option  value="50" class="dropdown-item">Custom</option>
         </select>  
         <a href="https://budibase.com/contact/" target="_blank"><button type="submit"
@@ -275,36 +252,9 @@
   </div>
 </div>
 
-
-
-
 {{ partial "pricing-faqs.html" . }}
 {{ partial "cta.html" . }}
 {{ partial "footer.html" . }}
 
-<script>
-  const price = document.querySelector(".plan-price")
-  const packagePickers = document.querySelectorAll(".pricing-select")
-
-  function getPrice(dayPasses, planType) {
-    // change these to update prices 
-    const MULTIPLIERS = {
-      Free: 0.7,
-      Pro: 0.6,
-      Team: 0.7,
-      Business: 0.8
-    }
-
-    return MULTIPLIERS[planType] * dayPasses
-  }
-
-  // set up event listeners for the pickers
-  for (let picker of packagePickers) {
-    picker.addEventListener("change", e => {
-      const parent = e.target.parentElement
-      const planType = parent.querySelector(".plan-type").textContent
-      parent.querySelector(".plan-price").innerHTML = `$${getPrice(e.target.value, planType)}`
-    })
-  }
-  
-</script>
+<!-- JS -->
+<script src="{{ "js/pricing.js" | absURL }}"></script>

--- a/themes/budibase/static/js/pricing.js
+++ b/themes/budibase/static/js/pricing.js
@@ -1,0 +1,264 @@
+const numberFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2,
+})
+
+/**
+ * Given the supplies plan type and day passes data, set the picker options
+ */
+const setPickerOptions = (planType, dayPassesMap) => {
+  // add the options for this plan type
+  const pickerElement = document.getElementById(`${planType}-select`)
+  Object.entries(dayPassesMap).forEach(([dayPasses, prices], index) => {
+    pickerElement.options[index] = new Option(`${dayPasses} day passes /mo`, dayPasses)
+  })
+
+  // add listener to render selected price
+  pickerElement.addEventListener("change", e => {
+    const dayPasses = e.target.value
+    const yearlyPrice =  dayPassesMap[dayPasses].yearly
+    const monthlyPrice =  dayPassesMap[dayPasses].monthly
+
+    const parent = e.target.parentElement
+    parent.querySelector(".plan-price").innerHTML = `${formatPrice(yearlyPrice)}`
+    parent.querySelector(".plan-price-monthly").innerHTML = `${formatPrice(monthlyPrice)} billed monthly`
+  })
+
+  // send initial change event to render selected price
+  const firstDayPass = Object.keys(dayPassesMap)[0]
+  const event = new Event("change", { target: { value: firstDayPass }})
+  pickerElement.dispatchEvent(event)
+}
+
+const getDayPassesMap = (plan) => {
+  // e.g. { 100: { yearly: { dayPasses: 100, amountMonthly: 250000}, monthly: { dayPasses: 100, amountMonthly: 220000 } }
+  return plan.prices.reduce((curr, price) => {
+    if (!curr[price.dayPasses]) {
+      curr[price.dayPasses] = {}
+    }
+    curr[price.dayPasses][price.duration] = price
+    return curr
+  }, {})
+}
+
+function formatPrice (price) {
+  return numberFormatter.format(price.amountMonthly / 100)
+}
+
+function getPlans () {
+  return [
+    {
+      "type": "team",
+      "prices": [
+        {
+          "priceId": "price_1LhIQ3BkHwGm6cL2RDB7mNmw",
+          "amount": 307200,
+          "amountMonthly": 25600,
+          "currency": "usd",
+          "duration": "yearly",
+          "dayPasses": 400
+        },
+        {
+          "priceId": "price_1LhIPtBkHwGm6cL2FHHkPfSB",
+          "amount": 30720,
+          "amountMonthly": 30720,
+          "currency": "usd",
+          "duration": "monthly",
+          "dayPasses": 400
+        },
+        {
+          "priceId": "price_1LhIOrBkHwGm6cL2YrF8JMCI",
+          "amount": 237600,
+          "amountMonthly": 19800,
+          "currency": "usd",
+          "duration": "yearly",
+          "dayPasses": 300
+        },
+        {
+          "priceId": "price_1LhIOhBkHwGm6cL2M3boe6t9",
+          "amount": 23760,
+          "amountMonthly": 23760,
+          "currency": "usd",
+          "duration": "monthly",
+          "dayPasses": 300
+        },
+        {
+          "priceId": "price_1LhINnBkHwGm6cL2TPHdCnxW",
+          "amount": 163200,
+          "amountMonthly": 13600,
+          "currency": "usd",
+          "duration": "yearly",
+          "dayPasses": 200
+        },
+        {
+          "priceId": "price_1LhINbBkHwGm6cL2q2XIs3az",
+          "amount": 16320,
+          "amountMonthly": 16320,
+          "currency": "usd",
+          "duration": "monthly",
+          "dayPasses": 200
+        },
+        {
+          "priceId": "price_1LhEDgBkHwGm6cL2Iq7iA9SI",
+          "amount": 84000,
+          "amountMonthly": 7000,
+          "currency": "usd",
+          "duration": "yearly",
+          "dayPasses": 100
+        },
+        {
+          "priceId": "price_1LhEDgBkHwGm6cL2fbgY5T44",
+          "amount": 8400,
+          "amountMonthly": 8400,
+          "currency": "usd",
+          "duration": "monthly",
+          "dayPasses": 100
+        }
+      ]
+    },
+    {
+      "type": "pro",
+      "prices": [
+        {
+          "priceId": "price_1LhILuBkHwGm6cL275G0XODg",
+          "amount": 52200,
+          "amountMonthly": 4350,
+          "currency": "usd",
+          "duration": "yearly",
+          "dayPasses": 75
+        },
+        {
+          "priceId": "price_1LhILiBkHwGm6cL24aEokQLf",
+          "amount": 5220,
+          "amountMonthly": 5220,
+          "currency": "usd",
+          "duration": "monthly",
+          "dayPasses": 75
+        },
+        {
+          "priceId": "price_1LhEMPBkHwGm6cL2ZIu2viYE",
+          "amount": 36000,
+          "amountMonthly": 3000,
+          "currency": "usd",
+          "duration": "yearly",
+          "dayPasses": 50
+        },
+        {
+          "priceId": "price_1LhEJLBkHwGm6cL2x229Fhml",
+          "amount": 3600,
+          "amountMonthly": 3600,
+          "currency": "usd",
+          "duration": "monthly",
+          "dayPasses": 50
+        }
+      ]
+    },
+    {
+      "type": "business",
+      "prices": [
+        {
+          "priceId": "price_1LhFG7BkHwGm6cL2an5PKMK9",
+          "amount": 936000,
+          "amountMonthly": 78000,
+          "currency": "usd",
+          "duration": "yearly",
+          "dayPasses": 1000
+        },
+        {
+          "priceId": "price_1LhFFsBkHwGm6cL2YCw3Vwvh",
+          "amount": 93600,
+          "amountMonthly": 93600,
+          "currency": "usd",
+          "duration": "monthly",
+          "dayPasses": 1000
+        },
+        {
+          "priceId": "price_1LhETVBkHwGm6cL2dPglUpQr",
+          "amount": 1776000,
+          "amountMonthly": 148000,
+          "currency": "usd",
+          "duration": "yearly",
+          "dayPasses": 2000
+        },
+        {
+          "priceId": "price_1LhETKBkHwGm6cL2jM6LdKXk",
+          "amount": 177600,
+          "amountMonthly": 177600,
+          "currency": "usd",
+          "duration": "monthly",
+          "dayPasses": 2000
+        },
+        {
+          "priceId": "price_1LhERBBkHwGm6cL2saU3WM8l",
+          "amount": 1368000,
+          "amountMonthly": 114000,
+          "currency": "usd",
+          "duration": "yearly",
+          "dayPasses": 1500
+        },
+        {
+          "priceId": "price_1LhERBBkHwGm6cL26EbtKKFI",
+          "amount": 136800,
+          "amountMonthly": 136800,
+          "currency": "usd",
+          "duration": "monthly",
+          "dayPasses": 1500
+        },
+        {
+          "priceId": "price_1LhEP7BkHwGm6cL2oiYvoKHo",
+          "amount": 480000,
+          "amountMonthly": 40000,
+          "currency": "usd",
+          "duration": "yearly",
+          "dayPasses": 500
+        },
+        {
+          "priceId": "price_1LhEP7BkHwGm6cL2GjO9LuKU",
+          "amount": 48000,
+          "amountMonthly": 48000,
+          "currency": "usd",
+          "duration": "monthly",
+          "dayPasses": 500
+        }
+      ]
+    }
+  ]
+}
+
+function init () {
+  const plans = getPlans()
+  const planTypes = plans.map(p => p.type)
+  for (let planType of planTypes) {
+    const plan = plans.filter(p => p.type === planType)[0]
+    const dayPassesMap = getDayPassesMap(plan)
+    setPickerOptions(plan.type, dayPassesMap)
+  }
+}
+
+init()
+
+const goToAccountPortal = (planType) => {
+  let path
+  let query = ""
+
+  if (planType && planType === "free") {
+    path = "register"
+  } else {
+    path = "register"
+    query = "?redirect=/portal/upgrade"
+  }
+
+  if (window.location.href.includes("localhost")) {
+    window.open(`http://localhost:10001/${path}${query}`, '_blank')
+  } else {
+    if (query) {
+      query = query + "&"
+    } else {
+      query = "?"
+    }
+    query = query + "utm_source=website&utm_medium=cta&utm_campaign=open-source-pricing"
+    window.open(`https://account.budibase.app/${path}${query}`, '_blank')
+  }
+}


### PR DESCRIPTION
## Description

## Pricing

Update the pricing pages for cloud and self host to build prices based on the api response structure of `/api/plans` in account portal. This is the same response data that is used to populate the in-app upgrade ui. 

In this PR the data is embedded directly, the rationale for this is that this data will very rarely change and when loading from directly over the api there is a noticeable lag in populating the data. In future when we make updates we can query the account portal endpoint and re-embed the response here with minimal effort. This also provides a degree of protection to not breaking the website pricing page if we do create some bad or incomplete data in stripe. 

## Navigation to account portal

A new url parameter has been added to account portal `?redirect=/some/path`. This controls which page will be navigated to after the user has been loaded on a page. 

Specific examples of how this integrates with the buttons on the pricing page:

`Free > Create free account` -> Send to the register page 
- When authenticated 
   - redirect to budibase
- When unauthenticated
   - If an existing account logs in instead of registering -> redirect to budibase
   - If new account is created -> redirect to budibase

`Paid plan > Try for free` -> Send to the register page 
- When authenticated 
   - redirect to account portal upgrade page
- When unauthenticated
   - If an existing account logs in instead of registering -> redirect to account portal upgrade page
   - If new account is created -> redirect to account portal upgrade page

This puts the `/portal/upgrade` page in account portal on the critical path, there is no direct integration between the website pricing page and stripe, primarily as there is no way to distinguish between choosing an annual or monthly plan on the website. This also simplifies the integration quite a bit. 

## Screenshots

When already authenticated


https://user-images.githubusercontent.com/8755148/190115524-9c6d797a-7e49-4c6d-bff1-1c478c141992.mov


When not authenticated 

https://user-images.githubusercontent.com/8755148/190115772-a84fa0c9-cec7-4a38-8f62-fea2d1055142.mov

When creating new account - cloud / pro

https://user-images.githubusercontent.com/8755148/190116377-5cdf6349-a2e3-401b-a46d-a6099f9e194b.mov

When creating new account - cloud / free

https://user-images.githubusercontent.com/8755148/190116579-6d82d2a3-fe79-4a29-bc4f-438fee151ec3.mov

When creating new account - selfhost / pro

https://user-images.githubusercontent.com/8755148/190116832-933e35a4-7733-4413-bbeb-ce1c0876b1c9.mov

When creating new account - selfhost / free

https://user-images.githubusercontent.com/8755148/190116983-e6834e87-f5ec-4831-b410-65b83c85502a.mov



