### PR TITLE
Remove hidden plugins from the integration list

### DIFF
--- a/build/hugo.js
+++ b/build/hugo.js
@@ -31,7 +31,8 @@ const getDataFromApi = async () => {
       "x-budibase-app-id": BB_APP_ID,
     }
   );
-  return res.data.data;
+  const filtered = res.data.data.filter(i => !i.Hidden);
+  return filtered;
 };
 
 const toKebabCase = (string) => {

--- a/build/hugo.js
+++ b/build/hugo.js
@@ -31,8 +31,7 @@ const getDataFromApi = async () => {
       "x-budibase-app-id": BB_APP_ID,
     }
   );
-  const filtered = res.data.data.filter(i => !i.Hidden);
-  return filtered;
+  return res.data.data.filter(i => !i.Hidden);
 };
 
 const toKebabCase = (string) => {


### PR DESCRIPTION
Currently this amend is to hide Airtable from the website until we figure out whether we want to fix the Auth issue surrounding it.

Added a new column hidden, to allow the ability to dynamically hide plugins/integrations going forward.